### PR TITLE
fix #17 erase Return event

### DIFF
--- a/infra/ftx.cpp
+++ b/infra/ftx.cpp
@@ -108,11 +108,6 @@ void Ftx::Train2(IUsecase::Card &card) {
                                                    });
 
     components |= ftxui::CatchEvent([&](const ftxui::Event &event) {
-        if (event == ftxui::Event::Return) {
-            right_clicked();
-            return true;
-        }
-
         if (event.is_character()) {
             if (event.character() == "1") {
                 right_clicked();
@@ -151,13 +146,6 @@ void Ftx::Train1(IUsecase::Card &card) {
     auto components = ftxui::Container::Vertical({
                                                          show_button
                                                  });
-    components |= ftxui::CatchEvent([&](const ftxui::Event &event) {
-        if (event == ftxui::Event::Return) {
-            show_clicked();
-            return true;
-        }
-        return false;
-    });
 
     auto renderer = ftxui::Renderer(components, [&] {
         return ftxui::vbox({


### PR DESCRIPTION
원인
- button click 을 위해 enter를 누른 것이 event capture 에 걸려서 right_clicked() 가 호출되었다.
조치
- enter event 에 대한 처리를 제거했다. 생각해보니 굳이 필요하지 않은 이벤트였다.